### PR TITLE
Fix password restore redirect

### DIFF
--- a/pages/password-restore/password-restore.htm
+++ b/pages/password-restore/password-restore.htm
@@ -16,7 +16,7 @@ function onInit()
 
     $this->addComponent('Lovata\Buddies\Components\RestorePassword', 'RestorePassword', [
         'redirect_on' => 1,
-        'redirect_page' => 'password-restore-success',
+        'redirect_page' => 'password-restore-success/password-restore-success',
         'mode' => 'ajax',
     ]);
 }


### PR DESCRIPTION
This issue is related to a bug in the Buddies plugin in environment oc-docker-theme-develop. If you disable [email sending](https://github.com/oc-shopaholic/oc-buddies-plugin/blob/e95c47d5a8f2b406e64771e85eb4b7f331767c33/components/RestorePassword.php#L72), a redirect occurs.