### PR TITLE
fix category title

### DIFF
--- a/partials/catalog/catalog-page.htm
+++ b/partials/catalog/catalog-page.htm
@@ -1,17 +1,6 @@
 {% set arSEOParams = {'category': obActiveCategory} %}
 {% set obSeoModel = obActiveCategory %}
 
-<h1 class="uppercase font-medium text-xl md:text-3xl">
-    {{ SeoToolbox.getPageTitle(obSeoModel, arSEOParams)|default(obActiveCategory.name) }}
-</h1>
-{% if obActiveCategory.preview_text is not empty %}
-    <div class="w-full flex flex-col mt-4">
-        {% partial 'common/expandable-text/expandable-text'
-            description=obActiveCategory.preview_text
-            numberVisibleRows=3
-        %}
-    </div>
-{% endif %}
 <div class="grid md:grid-cols-4 mb-14 mt-6 md:mt-10">
     <section class="md:col-span-1">
         {% set obChildrenCategoryList = obActiveCategory.children().site() %}
@@ -34,6 +23,17 @@
         {% endif %}
     </section>
     <div class="_sorting-container w-full md:col-span-3">
+        <h1 class="uppercase font-medium text-xl md:text-3xl">
+            {{ SeoToolbox.getPageTitle(obSeoModel, arSEOParams)|default(obActiveCategory.name) }}
+        </h1>
+        {% if obActiveCategory.preview_text is not empty %}
+        <div class="w-full flex flex-col mt-4">
+            {% partial 'common/expandable-text/expandable-text'
+                description=obActiveCategory.preview_text
+                numberVisibleRows=3
+            %}
+        </div>
+        {% endif %}
         <div class="_sorting">
             {% partial 'product/product-list/product-list-wrapper' %}
         </div>

--- a/partials/product/product-page.htm
+++ b/partials/product/product-page.htm
@@ -12,7 +12,7 @@
             obOffer = obOffer
         %}
         {% partial 'product/product-gallery/product-gallery' arImages = obProduct.images %}
-        {% if obProduct.preview_text %}
+        {% if obProduct.preview_text is not empty %}
             <div class="w-full flex flex-col mt-7 md:mt-11">
                 {% partial 'common/expandable-text/expandable-text'
                     numberVisibleRows=3

--- a/partials/product/product-page.htm
+++ b/partials/product/product-page.htm
@@ -12,7 +12,7 @@
             obOffer = obOffer
         %}
         {% partial 'product/product-gallery/product-gallery' arImages = obProduct.images %}
-        {% if obProduct.preview_text is not empty %}
+        {% if obProduct.preview_text %}
             <div class="w-full flex flex-col mt-7 md:mt-11">
                 {% partial 'common/expandable-text/expandable-text'
                     numberVisibleRows=3


### PR DESCRIPTION
В товаре описание работает так: если описание помещается в три строки, то оно выводится полностью, если описание не помещается, то появляется кнопка с разворотом